### PR TITLE
fix: remove source maps from prod build

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GENERATE_SOURCEMAP=false

--- a/.gitignore
+++ b/.gitignore
@@ -73,11 +73,11 @@ web_modules/
 .yarn-integrity
 
 # dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
+# .env
+# .env.development.local
+# .env.test.local
+# .env.production.local
+# .env.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
#### Reminder! Every time you create a PR:
- add TWO Reviewers
- make sure the PR is to the correct branch
- merge the PR only after the approvals from the reviewers

#### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related requirement

no

#### 💡 Background and solution

Remove source maps from prod build with env variable